### PR TITLE
Fix GitHub icon corner position

### DIFF
--- a/index.css
+++ b/index.css
@@ -27,7 +27,7 @@ h1 {
 
 
 .github-corner {
-	position: absolute;
+	position: fixed;
 	top: 0;
 	right: 0;
 }


### PR DESCRIPTION
Changed position to fixed for consistent display during scrolling. This ensures the GitHub corner icon stays visible as users scroll the page